### PR TITLE
Fix for jumping so it matches the jump behavior of VRChat.

### DIFF
--- a/CyanEmu/Scripts/CyanEmuPickupHelper.cs
+++ b/CyanEmu/Scripts/CyanEmuPickupHelper.cs
@@ -9,8 +9,8 @@ namespace VRCPrefabs.CyanEmu
         // If the user releases the mouse button before this time, it will not fire on use up. 
         private const float INITIAL_PICKUP_DURATION_ = 0.5f;
         private const float MAX_PICKUP_DISTANCE_ = 0.25f;
-        private static Quaternion GRIP_OFFSET_ROTATION_ = Quaternion.Euler(0, 0, -90);
-        private static Quaternion GUN_OFFSET_ROTATION_ = Quaternion.Euler(-90, 0, -90);
+        private static Quaternion GRIP_OFFSET_ROTATION_ = Quaternion.Euler(0, 45, 0);
+        private static Quaternion GUN_OFFSET_ROTATION_ = Quaternion.Euler(0, -45, 0);
         
         private Rigidbody rigidbody_;
         private VRC_Pickup pickup_;

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -39,6 +39,7 @@ namespace VRCPrefabs.CyanEmu
         private const float STANDING_HEIGHT_ = 1.6f;
         private const float CROUCHING_HEIGHT_ = 1.0f;
         private const float PRONE_HEIGHT_ = 0.5f;
+        private const float SITTING_HEIGHT_ADJUSTMENT_ = STANDING_HEIGHT_ - (STANDING_HEIGHT_ * 0.55f);
 
         private const float STICK_TO_GROUND_FORCE_ = 2f;
         private const float RATE_OF_AIR_ACCELERATION_ = 5f;
@@ -290,7 +291,7 @@ namespace VRCPrefabs.CyanEmu
             menu_.layer = menuLayer;
             menu_.transform.parent = transform.parent;
             Canvas canvas = menu_.AddComponent<Canvas>();
-            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
             canvas.worldCamera = camera_;
             canvas.planeDistance = camera_.nearClipPlane + 0.1f;
             canvas.sortingOrder = 1000;
@@ -504,21 +505,23 @@ namespace VRCPrefabs.CyanEmu
                 currentStation_.ExitStation();
             }
 
-            currentStation_ = station;
-
             if (!station.IsMobile)
             {
                 characterController_.enabled = false;
+                station.EnterLocation.Translate(0f, -SITTING_HEIGHT_ADJUSTMENT_, 0f);
                 Teleport(station.EnterLocation, false);
                 mouseLook_.SetBaseRotation(station.EnterLocation);
                 mouseLook_.SetRotation(Quaternion.identity);
             }
+
+            currentStation_ = station;
         }
 
         public void ExitStation(CyanEmuStationHelper station)
         {
             currentStation_ = null;
             characterController_.enabled = true;
+            station.EnterLocation.Translate(0f, SITTING_HEIGHT_ADJUSTMENT_, 0f);
 
             if (!station.IsMobile)
             {

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -629,7 +629,7 @@ namespace VRCPrefabs.CyanEmu
             RotateView();
             if (!jump_ && characterController_.isGrounded && jumpSpeed_ > 0)
             {
-                jump_ = Input.GetButton("Jump");
+                jump_ = Input.GetButtonDown("Jump");
             }
 
             if (currentPickup_ != null)

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -92,7 +92,7 @@ namespace VRCPrefabs.CyanEmu
         private CollisionFlags collisionFlags_;
         private bool peviouslyGrounded_;
         private bool legacyLocomotion_;
-        private bool updatePosition_;
+        private bool updateStancePosition_;
 
         private Texture2D reticleTexture_;
 
@@ -153,7 +153,7 @@ namespace VRCPrefabs.CyanEmu
             cameraHolder.transform.SetParent(playerCamera_.transform, false);
             camera_ = cameraHolder.AddComponent<Camera>();
             camera_.cullingMask &= ~(1 << 18); // remove mirror reflection
-            updatePosition_ = false;
+            updateStancePosition_ = false;
 
             // TODO, make based on avatar armspan/settings
             cameraHolder.transform.localScale = Vector3.one * AVATAR_SCALE_;
@@ -518,7 +518,7 @@ namespace VRCPrefabs.CyanEmu
 
             currentStation_ = station;
             stance_ = Stance.SITTING;
-            updatePosition_ = true;
+            updateStancePosition_ = true;
         }
 
         public void ExitStation(CyanEmuStationHelper station)
@@ -533,7 +533,7 @@ namespace VRCPrefabs.CyanEmu
             mouseLook_.SetBaseRotation(null);
             jump_ = false;
             stance_ = Stance.STANDING;
-            updatePosition_ = true;
+            updateStancePosition_ = true;
         }
 
         public void PickupObject(CyanEmuPickupHelper pickup)
@@ -858,11 +858,9 @@ namespace VRCPrefabs.CyanEmu
 
         private void UpdateStance()
         {
-            bool updatePosition = false;
-
             if (Input.GetKeyDown(CyanEmuSettings.Instance.crouchKey) && currentStation_ == null)
             {
-                updatePosition = true;
+                updateStancePosition_ = true;
                 if (stance_ == Stance.CROUCHING)
                 {
                     stance_ = Stance.STANDING;
@@ -874,7 +872,7 @@ namespace VRCPrefabs.CyanEmu
             }
             if (Input.GetKeyDown(CyanEmuSettings.Instance.proneKey) && currentStation_ == null)
             {
-                updatePosition = true;
+                updateStancePosition_ = true;
                 if (stance_ == Stance.PRONE)
                 {
                     stance_ = Stance.STANDING;
@@ -886,14 +884,14 @@ namespace VRCPrefabs.CyanEmu
             }
             
 
-            if (updatePosition)
+            if (updateStancePosition_)
             {
                 Vector3 cameraPosition = playerCamera_.transform.localPosition;
                 cameraPosition.y = (stance_ == Stance.STANDING ? STANDING_HEIGHT_ : stance_ == Stance.CROUCHING ? CROUCHING_HEIGHT_ : stance_ == Stance.PRONE ? PRONE_HEIGHT_ : SITTING_HEIGHT_);
                 playerCamera_.transform.localPosition = cameraPosition;
             }
 
-            updatePosition_ = false;
+            updateStancePosition_ = false;
         }
 
         private void GetInput(out Vector2 speed, out Vector2 input)

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -27,7 +27,8 @@ namespace VRCPrefabs.CyanEmu
         private enum Stance {
             STANDING,
             CROUCHING,
-            PRONE
+            PRONE,
+            SITTING
         }
 
         public const float DEFAULT_RUN_SPEED_ = 4;
@@ -39,7 +40,7 @@ namespace VRCPrefabs.CyanEmu
         private const float STANDING_HEIGHT_ = 1.6f;
         private const float CROUCHING_HEIGHT_ = 1.0f;
         private const float PRONE_HEIGHT_ = 0.5f;
-        private const float SITTING_HEIGHT_ADJUSTMENT_ = STANDING_HEIGHT_ - (STANDING_HEIGHT_ * 0.55f);
+        private const float SITTING_HEIGHT_ = 0.88f;
 
         private const float STICK_TO_GROUND_FORCE_ = 2f;
         private const float RATE_OF_AIR_ACCELERATION_ = 5f;
@@ -91,6 +92,7 @@ namespace VRCPrefabs.CyanEmu
         private CollisionFlags collisionFlags_;
         private bool peviouslyGrounded_;
         private bool legacyLocomotion_;
+        private bool updatePosition_;
 
         private Texture2D reticleTexture_;
 
@@ -151,6 +153,7 @@ namespace VRCPrefabs.CyanEmu
             cameraHolder.transform.SetParent(playerCamera_.transform, false);
             camera_ = cameraHolder.AddComponent<Camera>();
             camera_.cullingMask &= ~(1 << 18); // remove mirror reflection
+            updatePosition_ = false;
 
             // TODO, make based on avatar armspan/settings
             cameraHolder.transform.localScale = Vector3.one * AVATAR_SCALE_;
@@ -508,20 +511,20 @@ namespace VRCPrefabs.CyanEmu
             if (!station.IsMobile)
             {
                 characterController_.enabled = false;
-                station.EnterLocation.Translate(0f, -SITTING_HEIGHT_ADJUSTMENT_, 0f);
                 Teleport(station.EnterLocation, false);
                 mouseLook_.SetBaseRotation(station.EnterLocation);
                 mouseLook_.SetRotation(Quaternion.identity);
             }
 
             currentStation_ = station;
+            stance_ = Stance.SITTING;
+            updatePosition_ = true;
         }
 
         public void ExitStation(CyanEmuStationHelper station)
         {
             currentStation_ = null;
             characterController_.enabled = true;
-            station.EnterLocation.Translate(0f, SITTING_HEIGHT_ADJUSTMENT_, 0f);
 
             if (!station.IsMobile)
             {
@@ -529,6 +532,8 @@ namespace VRCPrefabs.CyanEmu
             }
             mouseLook_.SetBaseRotation(null);
             jump_ = false;
+            stance_ = Stance.STANDING;
+            updatePosition_ = true;
         }
 
         public void PickupObject(CyanEmuPickupHelper pickup)
@@ -884,9 +889,11 @@ namespace VRCPrefabs.CyanEmu
             if (updatePosition)
             {
                 Vector3 cameraPosition = playerCamera_.transform.localPosition;
-                cameraPosition.y = (stance_ == Stance.STANDING ? STANDING_HEIGHT_ : stance_ == Stance.CROUCHING ? CROUCHING_HEIGHT_ : PRONE_HEIGHT_);
+                cameraPosition.y = (stance_ == Stance.STANDING ? STANDING_HEIGHT_ : stance_ == Stance.CROUCHING ? CROUCHING_HEIGHT_ : stance_ == Stance.PRONE ? PRONE_HEIGHT_ : SITTING_HEIGHT_);
                 playerCamera_.transform.localPosition = cameraPosition;
             }
+
+            updatePosition_ = false;
         }
 
         private void GetInput(out Vector2 speed, out Vector2 input)

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -860,7 +860,7 @@ namespace VRCPrefabs.CyanEmu
         {
             bool updatePosition = false;
 
-            if (Input.GetKeyDown(CyanEmuSettings.Instance.crouchKey))
+            if (Input.GetKeyDown(CyanEmuSettings.Instance.crouchKey) && currentStation_ == null)
             {
                 updatePosition = true;
                 if (stance_ == Stance.CROUCHING)
@@ -872,7 +872,7 @@ namespace VRCPrefabs.CyanEmu
                     stance_ = Stance.CROUCHING;
                 }
             }
-            if (Input.GetKeyDown(CyanEmuSettings.Instance.proneKey))
+            if (Input.GetKeyDown(CyanEmuSettings.Instance.proneKey) && currentStation_ == null)
             {
                 updatePosition = true;
                 if (stance_ == Stance.PRONE)


### PR DESCRIPTION
In VRChat, when the jump button is held, the player will jump once, and then stay on the ground until the key is pressed again. In CyanEmu, the character will repeatedly jump as long as the button is held. This inconsistency introduces difficulties in certain cases when attempting to test Udon code that alters the jump behavior.