### PR TITLE
Fixed jumping when button held, to match behavior of VRChat.

### DIFF
--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -629,7 +629,7 @@ namespace VRCPrefabs.CyanEmu
             RotateView();
             if (!jump_ && characterController_.isGrounded && jumpSpeed_ > 0)
             {
-                jump_ = Input.GetButton("Jump");
+                jump_ = Input.GetButtonDown("Jump");
             }
 
             if (currentPickup_ != null)


### PR DESCRIPTION
Holding jump in VRChat causes only one jump until it is pressed again. However in CyanEmu, holding jump instead causes the player to repeatedly jump. This has been corrected to match the behavior of VRChat.