### PR TITLE
Changed initial arm positions and rotations to be more accurate with VRChat

### DIFF
--- a/CyanEmu/Scripts/CyanEmuPickupHelper.cs
+++ b/CyanEmu/Scripts/CyanEmuPickupHelper.cs
@@ -9,7 +9,7 @@ namespace VRCPrefabs.CyanEmu
         // If the user releases the mouse button before this time, it will not fire on use up. 
         private const float INITIAL_PICKUP_DURATION_ = 0.5f;
         private const float MAX_PICKUP_DISTANCE_ = 0.25f;
-        private static Quaternion GRIP_OFFSET_ROTATION_ = Quaternion.Euler(0, 45, 0);
+        private static Quaternion GRIP_OFFSET_ROTATION_ = Quaternion.Euler(0, 35, 0);
         private static Quaternion GUN_OFFSET_ROTATION_ = Quaternion.Euler(0, 305, 0);
         
         private Rigidbody rigidbody_;

--- a/CyanEmu/Scripts/CyanEmuPickupHelper.cs
+++ b/CyanEmu/Scripts/CyanEmuPickupHelper.cs
@@ -10,7 +10,7 @@ namespace VRCPrefabs.CyanEmu
         private const float INITIAL_PICKUP_DURATION_ = 0.5f;
         private const float MAX_PICKUP_DISTANCE_ = 0.25f;
         private static Quaternion GRIP_OFFSET_ROTATION_ = Quaternion.Euler(0, 45, 0);
-        private static Quaternion GUN_OFFSET_ROTATION_ = Quaternion.Euler(0, -45, 0);
+        private static Quaternion GUN_OFFSET_ROTATION_ = Quaternion.Euler(0, 305, 0);
         
         private Rigidbody rigidbody_;
         private VRC_Pickup pickup_;

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -170,15 +170,15 @@ namespace VRCPrefabs.CyanEmu
 
             rightArmPosition_ = new GameObject("Right Arm Position");
             rightArmPosition_.transform.SetParent(playerCamera_.transform, false);
-            rightArmPosition_.transform.localPosition = new Vector3(0.2f, -0.2f, 0.75f);
-            rightArmPosition_.transform.localRotation = Quaternion.Euler(-45, 0, -90);
+            rightArmPosition_.transform.localPosition = new Vector3(0.1527f, -0.029f, 0.4180f);
+            rightArmPosition_.transform.localRotation = Quaternion.Euler(-35, 0, -90);
             rightArmRigidbody_ = rightArmPosition_.AddComponent<Rigidbody>();
             rightArmRigidbody_.isKinematic = true;
             
             leftArmPosition_ = new GameObject("Left Arm Position");
             leftArmPosition_.transform.SetParent(playerCamera_.transform, false);
-            leftArmPosition_.transform.localPosition = new Vector3(-0.2f, -0.2f, 0.75f);
-            leftArmPosition_.transform.localRotation = Quaternion.Euler(-45, 0, -90);
+            leftArmPosition_.transform.localPosition = new Vector3(-0.1473f, 0.0025f, 0.4180f);
+            leftArmPosition_.transform.localRotation = Quaternion.Euler(-35, 0, -90);
             leftArmRigidbody_ = leftArmPosition_.AddComponent<Rigidbody>();
             leftArmRigidbody_.isKinematic = true;
             

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -170,14 +170,14 @@ namespace VRCPrefabs.CyanEmu
 
             rightArmPosition_ = new GameObject("Right Arm Position");
             rightArmPosition_.transform.SetParent(playerCamera_.transform, false);
-            rightArmPosition_.transform.localPosition = new Vector3(0.1527f, -0.0091f, 0.4180f);
+            rightArmPosition_.transform.localPosition = new Vector3(0.15f, -0.13f, 0.4f);
             rightArmPosition_.transform.localRotation = Quaternion.Euler(-35, 0, -90);
             rightArmRigidbody_ = rightArmPosition_.AddComponent<Rigidbody>();
             rightArmRigidbody_.isKinematic = true;
             
             leftArmPosition_ = new GameObject("Left Arm Position");
             leftArmPosition_.transform.SetParent(playerCamera_.transform, false);
-            leftArmPosition_.transform.localPosition = new Vector3(-0.1473f, -0.0091f, 0.4180f);
+            leftArmPosition_.transform.localPosition = new Vector3(-0.15f, -0.13f, 0.4f);
             leftArmPosition_.transform.localRotation = Quaternion.Euler(-35, 0, -90);
             leftArmRigidbody_ = leftArmPosition_.AddComponent<Rigidbody>();
             leftArmRigidbody_.isKinematic = true;

--- a/CyanEmu/Scripts/CyanEmuPlayerController.cs
+++ b/CyanEmu/Scripts/CyanEmuPlayerController.cs
@@ -170,14 +170,14 @@ namespace VRCPrefabs.CyanEmu
 
             rightArmPosition_ = new GameObject("Right Arm Position");
             rightArmPosition_.transform.SetParent(playerCamera_.transform, false);
-            rightArmPosition_.transform.localPosition = new Vector3(0.1527f, -0.029f, 0.4180f);
+            rightArmPosition_.transform.localPosition = new Vector3(0.1527f, -0.0091f, 0.4180f);
             rightArmPosition_.transform.localRotation = Quaternion.Euler(-35, 0, -90);
             rightArmRigidbody_ = rightArmPosition_.AddComponent<Rigidbody>();
             rightArmRigidbody_.isKinematic = true;
             
             leftArmPosition_ = new GameObject("Left Arm Position");
             leftArmPosition_.transform.SetParent(playerCamera_.transform, false);
-            leftArmPosition_.transform.localPosition = new Vector3(-0.1473f, 0.0025f, 0.4180f);
+            leftArmPosition_.transform.localPosition = new Vector3(-0.1473f, -0.0091f, 0.4180f);
             leftArmPosition_.transform.localRotation = Quaternion.Euler(-35, 0, -90);
             leftArmRigidbody_ = leftArmPosition_.AddComponent<Rigidbody>();
             leftArmRigidbody_.isKinematic = true;


### PR DESCRIPTION
After some comparisons with vrchat and cyan emu's tracking data positions, I have edited the initial starting positions and rotations for the arms on cyan emu to more closely fit with vrchat.